### PR TITLE
Add CNES establishment ingestion utilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/br/com/cneshub/ingestor/CkanClient.java
+++ b/src/main/java/br/com/cneshub/ingestor/CkanClient.java
@@ -1,0 +1,64 @@
+package br.com.cneshub.ingestor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Client to interact with CKAN API.
+ */
+@Component
+public class CkanClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CkanClient.class);
+
+    private final String baseUrl;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    public CkanClient(@Value("${cneshub.ingest.baseUrl}") String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * Downloads the CSV resource to the given destination path.
+     *
+     * @param resourceId resource identifier on CKAN
+     * @param destino    destination path for the downloaded file
+     */
+    public void downloadCsv(String resourceId, Path destino) {
+        String url = String.format("%s/datastore/dump/%s?format=csv", baseUrl, resourceId);
+        try (InputStream in = streamCsvFromUrl(url)) {
+            Files.createDirectories(destino.getParent());
+            Files.copy(in, destino);
+        } catch (IOException e) {
+            throw new RuntimeException("Falha ao baixar recurso do CKAN", e);
+        }
+    }
+
+    /**
+     * Streams CSV content from a direct URL.
+     *
+     * @param url URL pointing to CSV
+     * @return input stream of the CSV
+     */
+    public InputStream streamCsvFromUrl(String url) {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        try {
+            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            return response.body();
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Falha ao obter stream do CKAN", e);
+        }
+    }
+}

--- a/src/main/java/br/com/cneshub/ingestor/EstabelecimentoCsvParser.java
+++ b/src/main/java/br/com/cneshub/ingestor/EstabelecimentoCsvParser.java
@@ -1,0 +1,112 @@
+package br.com.cneshub.ingestor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Parses Estabelecimentos CSV and stores it in the staging table.
+ */
+@Component
+public class EstabelecimentoCsvParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EstabelecimentoCsvParser.class);
+    private static final int BATCH_SIZE = 1000;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    public EstabelecimentoCsvParser(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public ParseResult parse(InputStream inputStream, boolean storeRawJson) throws IOException {
+        long start = System.currentTimeMillis();
+        try (Reader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+             CSVParser parser = CSVFormat.DEFAULT.withFirstRecordAsHeader().withDelimiter(';').parse(reader)) {
+
+            List<CSVRecord> batch = new ArrayList<>(BATCH_SIZE);
+            int inserted = 0;
+            for (CSVRecord record : parser) {
+                batch.add(record);
+                if (batch.size() == BATCH_SIZE) {
+                    inserted += flush(batch, storeRawJson);
+                    batch.clear();
+                }
+            }
+            if (!batch.isEmpty()) {
+                inserted += flush(batch, storeRawJson);
+            }
+            long lines = parser.getRecordNumber();
+            int rejected = (int) (lines - inserted);
+            Duration duration = Duration.ofMillis(System.currentTimeMillis() - start);
+            return new ParseResult(lines, inserted, rejected, duration);
+        }
+    }
+
+    private int flush(List<CSVRecord> batch, boolean storeRawJson) {
+        String sql = "INSERT INTO staging_estabelecimentos (cnes, nome, uf, municipio, cod_municipio, tipo_estab, logradouro, numero, bairro, cep, telefone, email, competencia, raw_json) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+        int[] results = jdbcTemplate.batchUpdate(sql, batch, BATCH_SIZE, (ps, record) -> {
+            ps.setString(1, field(record, "cnes"));
+            ps.setString(2, field(record, "nome"));
+            ps.setString(3, field(record, "uf"));
+            ps.setString(4, field(record, "municipio"));
+            ps.setString(5, field(record, "cod_municipio"));
+            ps.setString(6, field(record, "tipo_estab"));
+            ps.setString(7, field(record, "logradouro"));
+            ps.setString(8, field(record, "numero"));
+            ps.setString(9, field(record, "bairro"));
+            ps.setString(10, field(record, "cep"));
+            ps.setString(11, field(record, "telefone"));
+            ps.setString(12, field(record, "email"));
+            ps.setString(13, field(record, "competencia"));
+            if (storeRawJson) {
+                try {
+                    ps.setString(14, objectMapper.writeValueAsString(record.toMap()));
+                } catch (JsonProcessingException e) {
+                    throw new SQLException("Erro ao serializar linha para JSON", e);
+                }
+            } else {
+                ps.setNull(14, Types.VARCHAR);
+            }
+        });
+        return Arrays.stream(results).sum();
+    }
+
+    private String field(CSVRecord record, String name) {
+        if (record.isMapped(name)) {
+            return record.get(name);
+        }
+        String upper = name.toUpperCase();
+        if (record.isMapped(upper)) {
+            return record.get(upper);
+        }
+        String lower = name.toLowerCase();
+        if (record.isMapped(lower)) {
+            return record.get(lower);
+        }
+        return null;
+    }
+
+    public record ParseResult(long linesRead, int inserted, int rejected, Duration duration) {}
+}
+

--- a/src/main/java/br/com/cneshub/ingestor/EstabelecimentoIngestService.java
+++ b/src/main/java/br/com/cneshub/ingestor/EstabelecimentoIngestService.java
@@ -1,0 +1,81 @@
+package br.com.cneshub.ingestor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.DigestInputStream;
+
+/**
+ * Service responsible for ingesting Estabelecimentos CSV files.
+ */
+@Service
+public class EstabelecimentoIngestService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EstabelecimentoIngestService.class);
+
+    private final EstabelecimentoCsvParser parser;
+    private final JdbcTemplate jdbcTemplate;
+    private final boolean storeRawJson;
+
+    public EstabelecimentoIngestService(EstabelecimentoCsvParser parser,
+                                        JdbcTemplate jdbcTemplate,
+                                        @Value("${cneshub.ingest.store-raw-json:false}") boolean storeRawJson) {
+        this.parser = parser;
+        this.jdbcTemplate = jdbcTemplate;
+        this.storeRawJson = storeRawJson;
+    }
+
+    /**
+     * Ingests data from the provided CSV file path.
+     *
+     * @param arquivo path to CSV file
+     */
+    public void ingestFromCsv(Path arquivo) throws IOException {
+        String hash = hash(arquivo);
+        Integer exists = jdbcTemplate.queryForObject("SELECT count(1) FROM ingest_file WHERE file_hash = ?", Integer.class, hash);
+        if (exists != null && exists > 0) {
+            LOGGER.info("Arquivo {} já processado", arquivo);
+            return;
+        }
+        long start = System.currentTimeMillis();
+        try (InputStream in = Files.newInputStream(arquivo)) {
+            EstabelecimentoCsvParser.ParseResult result = parser.parse(in, storeRawJson);
+            jdbcTemplate.update("INSERT INTO ingest_file(file_hash) VALUES (?)", hash);
+            long total = System.currentTimeMillis() - start;
+            LOGGER.info("Ingestão concluída em {} ms - linhas lidas: {}, inseridas: {}, rejeitadas: {}",
+                    total, result.linesRead(), result.inserted(), result.rejected());
+        }
+    }
+
+    private String hash(Path arquivo) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not disponível", e);
+        }
+        try (InputStream in = Files.newInputStream(arquivo);
+             DigestInputStream dis = new DigestInputStream(in, digest)) {
+            byte[] buffer = new byte[8192];
+            while (dis.read(buffer) != -1) {
+                // ler arquivo
+            }
+        }
+        byte[] hash = digest.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : hash) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,7 @@ cneshub:
   security:
     apiKeyEnabled: false
     apiKey: trocar-em-producao
+  ingest:
+    baseUrl: https://dados.gov.br
+    datasets:
+      estabelecimentos: RESOURCE_ID

--- a/src/main/resources/db/migration/V2__ingest_file_hash.sql
+++ b/src/main/resources/db/migration/V2__ingest_file_hash.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS ingest_file (
+    file_hash VARCHAR(64) PRIMARY KEY,
+    processed_at TIMESTAMP DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add CKAN client to download or stream CSV resources
- parse establishment CSV to staging table with batch insert
- ingest service calculates file hash to skip reprocessing and log results
- configure ingest properties and migration for processed files

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b2458ef8832a841e316c9519aff3