### PR TITLE
feat: add CKAN client with resilience and caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
@@ -71,6 +75,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/java/br/com/cneshub/BrCnesHubApiApplication.java
+++ b/src/main/java/br/com/cneshub/BrCnesHubApiApplication.java
@@ -2,8 +2,10 @@ package br.com.cneshub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class BrCnesHubApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/br/com/cneshub/config/WebClientConfig.java
+++ b/src/main/java/br/com/cneshub/config/WebClientConfig.java
@@ -1,0 +1,34 @@
+package br.com.cneshub.config;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import reactor.netty.http.client.HttpClient;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient ckanWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(5))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(5))
+                        .addHandlerLast(new WriteTimeoutHandler(5)));
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.USER_AGENT, "br-cnes-hub-api")
+                .defaultHeader(HttpHeaders.ACCEPT_ENCODING, "gzip")
+                .build();
+    }
+}

--- a/src/main/java/br/com/cneshub/core/CnesService.java
+++ b/src/main/java/br/com/cneshub/core/CnesService.java
@@ -1,0 +1,58 @@
+package br.com.cneshub.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import br.com.cneshub.core.dto.CkanResponse;
+import br.com.cneshub.core.dto.EstabelecimentoDTO;
+import br.com.cneshub.ingestor.CkanClient;
+
+@Service
+public class CnesService {
+
+    private final CkanClient ckanClient;
+    private final String resourceId;
+
+    public CnesService(CkanClient ckanClient,
+                       @Value("${cneshub.ingest.datasets.estabelecimentos}") String resourceId) {
+        this.ckanClient = ckanClient;
+        this.resourceId = resourceId;
+    }
+
+    @Cacheable(cacheNames = "estabelecimentos", key = "T(br.com.cneshub.core.CnesService).cacheKey(#filtros,#page,#size,#raw)")
+    public CkanResponse<EstabelecimentoDTO> buscarEstabelecimentos(Map<String, String> filtros, int page, int size, boolean raw) {
+        int offset = Math.max(page, 0) * size;
+        CkanResponse<Map<String, Object>> response = ckanClient.datastoreSearch(resourceId, filtros, offset, size);
+        List<EstabelecimentoDTO> records = response.getRecords().stream()
+                .map(map -> toDto(map, raw))
+                .collect(Collectors.toList());
+        return new CkanResponse<>(response.getTotal(), response.getLimit(), response.getOffset(), records,
+                raw ? response.getRaw() : null);
+    }
+
+    private EstabelecimentoDTO toDto(Map<String, Object> record, boolean raw) {
+        EstabelecimentoDTO dto = new EstabelecimentoDTO();
+        dto.setCnes((String) record.get("cnes"));
+        dto.setNome((String) record.get("nome"));
+        dto.setUf((String) record.get("uf"));
+        dto.setMunicipio((String) record.get("municipio"));
+        dto.setCodMunicipio((String) record.get("cod_municipio"));
+        if (raw) {
+            dto.setExtra(record);
+        }
+        return dto;
+    }
+
+    public static String cacheKey(Map<String, String> filtros, int page, int size, boolean raw) {
+        String filtrosKey = filtros == null ? "" : filtros.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> e.getKey() + '=' + e.getValue())
+                .collect(Collectors.joining("&"));
+        return filtrosKey + '|' + page + '|' + size + '|' + raw;
+    }
+}

--- a/src/main/java/br/com/cneshub/core/dto/CkanResponse.java
+++ b/src/main/java/br/com/cneshub/core/dto/CkanResponse.java
@@ -1,0 +1,19 @@
+package br.com.cneshub.core.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CkanResponse<T> {
+    private int total;
+    private int limit;
+    private int offset;
+    private List<T> records;
+    private Map<String, Object> raw;
+}

--- a/src/main/java/br/com/cneshub/core/dto/EstabelecimentoDTO.java
+++ b/src/main/java/br/com/cneshub/core/dto/EstabelecimentoDTO.java
@@ -1,0 +1,15 @@
+package br.com.cneshub.core.dto;
+
+import java.util.Map;
+
+import lombok.Data;
+
+@Data
+public class EstabelecimentoDTO {
+    private String cnes;
+    private String nome;
+    private String uf;
+    private String municipio;
+    private String codMunicipio;
+    private Map<String, Object> extra;
+}

--- a/src/main/java/br/com/cneshub/ingestor/CkanClient.java
+++ b/src/main/java/br/com/cneshub/ingestor/CkanClient.java
@@ -1,64 +1,101 @@
 package br.com.cneshub.ingestor;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import br.com.cneshub.core.dto.CkanResponse;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
+import reactor.core.publisher.Mono;
 
 /**
- * Client to interact with CKAN API.
+ * Client to interact with CKAN API using WebClient.
  */
 @Component
 public class CkanClient {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CkanClient.class);
+    private final WebClient webClient;
+    private final Map<String, String> etags = new ConcurrentHashMap<>();
 
-    private final String baseUrl;
-    private final HttpClient httpClient = HttpClient.newHttpClient();
-
-    public CkanClient(@Value("${cneshub.ingest.baseUrl}") String baseUrl) {
-        this.baseUrl = baseUrl;
+    public CkanClient(WebClient ckanWebClient, @Value("${cneshub.ingest.baseUrl}") String baseUrl) {
+        this.webClient = ckanWebClient.mutate().baseUrl(baseUrl).build();
     }
 
-    /**
-     * Downloads the CSV resource to the given destination path.
-     *
-     * @param resourceId resource identifier on CKAN
-     * @param destino    destination path for the downloaded file
-     */
-    public void downloadCsv(String resourceId, Path destino) {
-        String url = String.format("%s/datastore/dump/%s?format=csv", baseUrl, resourceId);
-        try (InputStream in = streamCsvFromUrl(url)) {
-            Files.createDirectories(destino.getParent());
-            Files.copy(in, destino);
-        } catch (IOException e) {
-            throw new RuntimeException("Falha ao baixar recurso do CKAN", e);
+    @CircuitBreaker(name = "ckan")
+    @Retry(name = "ckan")
+    @RateLimiter(name = "ckan")
+    public CkanResponse<Map<String, Object>> datastoreSearch(String resourceId, Map<String, String> params, int offset, int limit) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/datastore_search")
+                .queryParam("resource_id", resourceId)
+                .queryParam("offset", offset)
+                .queryParam("limit", limit);
+        if (params != null) {
+            params.forEach(builder::queryParam);
         }
+        String uri = builder.toUriString();
+        WebClient.RequestHeadersSpec<?> request = webClient.get().uri(uri);
+        String etag = etags.get(uri);
+        if (etag != null) {
+            request = request.header(HttpHeaders.IF_NONE_MATCH, etag);
+        }
+        return request.exchangeToMono(resp -> {
+            if (resp.statusCode().equals(HttpStatus.NOT_MODIFIED)) {
+                return Mono.just(new CkanResponse<>(0, limit, offset, List.of(), Collections.emptyMap()));
+            }
+            if (!resp.statusCode().is2xxSuccessful()) {
+                return resp.createException().flatMap(Mono::error);
+            }
+            String newEtag = resp.headers().asHttpHeaders().getFirst(HttpHeaders.ETAG);
+            if (newEtag != null) {
+                etags.put(uri, newEtag);
+            }
+            return resp.bodyToMono(Map.class).map(this::toCkanResponse);
+        }).block();
     }
 
-    /**
-     * Streams CSV content from a direct URL.
-     *
-     * @param url URL pointing to CSV
-     * @return input stream of the CSV
-     */
-    public InputStream streamCsvFromUrl(String url) {
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
-        try {
-            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
-            return response.body();
-        } catch (IOException | InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Falha ao obter stream do CKAN", e);
+    @CircuitBreaker(name = "ckan")
+    @Retry(name = "ckan")
+    @RateLimiter(name = "ckan")
+    public CkanResponse<Map<String, Object>> datastoreSearchSql(String sql) {
+        String uri = UriComponentsBuilder.fromPath("/datastore_search_sql")
+                .queryParam("sql", sql).toUriString();
+        WebClient.RequestHeadersSpec<?> request = webClient.get().uri(uri);
+        String etag = etags.get(uri);
+        if (etag != null) {
+            request = request.header(HttpHeaders.IF_NONE_MATCH, etag);
         }
+        return request.exchangeToMono(resp -> {
+            if (resp.statusCode().equals(HttpStatus.NOT_MODIFIED)) {
+                return Mono.just(new CkanResponse<>(0, 0, 0, List.of(), Collections.emptyMap()));
+            }
+            if (!resp.statusCode().is2xxSuccessful()) {
+                return resp.createException().flatMap(Mono::error);
+            }
+            String newEtag = resp.headers().asHttpHeaders().getFirst(HttpHeaders.ETAG);
+            if (newEtag != null) {
+                etags.put(uri, newEtag);
+            }
+            return resp.bodyToMono(Map.class).map(this::toCkanResponse);
+        }).block();
+    }
+
+    @SuppressWarnings("unchecked")
+    private CkanResponse<Map<String, Object>> toCkanResponse(Map<String, Object> body) {
+        Map<String, Object> result = (Map<String, Object>) body.getOrDefault("result", Collections.emptyMap());
+        int total = ((Number) result.getOrDefault("total", 0)).intValue();
+        int limit = ((Number) result.getOrDefault("limit", 0)).intValue();
+        int offset = ((Number) result.getOrDefault("offset", 0)).intValue();
+        List<Map<String, Object>> records = (List<Map<String, Object>>) result.getOrDefault("records", List.of());
+        return new CkanResponse<>(total, limit, offset, records, result);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,23 @@ cneshub:
     apiKeyEnabled: false
     apiKey: trocar-em-producao
   ingest:
-    baseUrl: https://dados.gov.br
+    baseUrl: https://opendatasus.saude.gov.br/api/3/action
     datasets:
       estabelecimentos: RESOURCE_ID
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      ckan:
+        sliding-window-size: 20
+        failure-rate-threshold: 50
+  retry:
+    instances:
+      ckan:
+        max-attempts: 3
+        wait-duration: 500ms
+  ratelimiter:
+    instances:
+      ckan:
+        limit-for-period: 10
+        limit-refresh-period: 1s


### PR DESCRIPTION
## Summary
- add WebFlux and Resilience4j dependencies
- implement CKAN WebClient with ETag handling and resilience
- create CNES service with caching and DTOs
- configure application properties for CKAN access and Resilience4j

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b4314204832abf6f1332bd412564