### PR TITLE
feat: gateway stateless para dados do CNES

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,28 @@
 	      <groupId>org.springframework.boot</groupId>
 	      <artifactId>spring-boot-starter-cache</artifactId>
 	    </dependency>
-	    <dependency>
-	      <groupId>com.github.ben-manes.caffeine</groupId>
-	      <artifactId>caffeine</artifactId>
-	    </dependency>
+            <dependency>
+              <groupId>com.github.ben-manes.caffeine</groupId>
+              <artifactId>caffeine</artifactId>
+            </dependency>
+
+            <!-- Resilience4j para tolerância a falhas -->
+            <dependency>
+              <groupId>io.github.resilience4j</groupId>
+              <artifactId>resilience4j-spring-boot3</artifactId>
+            </dependency>
+
+            <!-- Documentação OpenAPI/Swagger -->
+            <dependency>
+              <groupId>org.springdoc</groupId>
+              <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            </dependency>
+
+            <!-- Utilidades -->
+            <dependency>
+              <groupId>org.apache.commons</groupId>
+              <artifactId>commons-csv</artifactId>
+            </dependency>
 	
 	
 		<dependency>

--- a/src/main/java/br/com/cneshub/BrCnesHubApiApplication.java
+++ b/src/main/java/br/com/cneshub/BrCnesHubApiApplication.java
@@ -2,12 +2,15 @@ package br.com.cneshub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import br.com.cneshub.client.CkanProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(CkanProperties.class)
 public class BrCnesHubApiApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BrCnesHubApiApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(BrCnesHubApiApplication.class, args);
+    }
 }

--- a/src/main/java/br/com/cneshub/api/v1/EstabelecimentoController.java
+++ b/src/main/java/br/com/cneshub/api/v1/EstabelecimentoController.java
@@ -1,0 +1,47 @@
+package br.com.cneshub.api.v1;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.cneshub.core.EstabelecimentoService;
+import br.com.cneshub.core.dto.CkanEnvelope;
+import br.com.cneshub.core.dto.EstabelecimentoDTO;
+import br.com.cneshub.core.dto.PageResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class EstabelecimentoController {
+
+    private final EstabelecimentoService service;
+
+    @Value("${cneshub.cache.ttl}")
+    private Duration cacheTtl;
+
+    @GetMapping("/estabelecimentos")
+    public ResponseEntity<?> listar(
+            @RequestParam(required = false) String uf,
+            @RequestParam(required = false) String municipio,
+            @RequestParam(required = false) String tipo,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "false") boolean raw) {
+
+        CkanEnvelope<EstabelecimentoDTO> envelope = service.buscar(uf, municipio, tipo, page, size, q);
+        CacheControl cache = CacheControl.maxAge(cacheTtl);
+        if (raw) {
+            return ResponseEntity.ok().cacheControl(cache).body(envelope);
+        }
+        PageResponse<EstabelecimentoDTO> pagina = service.toPage(envelope, page, size);
+        return ResponseEntity.ok().cacheControl(cache).body(pagina);
+    }
+}

--- a/src/main/java/br/com/cneshub/client/CkanClient.java
+++ b/src/main/java/br/com/cneshub/client/CkanClient.java
@@ -1,5 +1,59 @@
 package br.com.cneshub.client;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import br.com.cneshub.core.dto.CkanEnvelope;
+import br.com.cneshub.core.dto.EstabelecimentoDTO;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
 public class CkanClient {
 
+    private final WebClient webClient;
+    private final CkanProperties properties;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public CkanEnvelope<EstabelecimentoDTO> buscar(String uf, String municipio, String tipo, int page, int size, String q) {
+        int offset = page * size;
+        Map<String, String> filtros = new HashMap<>();
+        if (uf != null) filtros.put("uf", uf);
+        if (municipio != null) filtros.put("municipio", municipio);
+        if (tipo != null) filtros.put("co_tipo_estabelecimento", tipo);
+
+        String filtrosJson = null;
+        if (!filtros.isEmpty()) {
+            try {
+                filtrosJson = mapper.writeValueAsString(filtros);
+            } catch (JsonProcessingException e) {
+                throw new IllegalArgumentException("Erro ao serializar filtros", e);
+            }
+        }
+
+        return webClient.get()
+                .uri(builder -> {
+                    builder.path("/datastore_search")
+                        .queryParam("resource_id", properties.getDatasets().getEstabelecimentos())
+                        .queryParam("limit", size)
+                        .queryParam("offset", offset);
+                    if (q != null && !q.isEmpty()) {
+                        builder.queryParam("q", q);
+                    }
+                    if (filtrosJson != null) {
+                        builder.queryParam("filters", filtrosJson);
+                    }
+                    return builder.build();
+                })
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<CkanEnvelope<EstabelecimentoDTO>>() {})
+                .block();
+    }
 }

--- a/src/main/java/br/com/cneshub/client/CkanProperties.java
+++ b/src/main/java/br/com/cneshub/client/CkanProperties.java
@@ -1,5 +1,20 @@
 package br.com.cneshub.client;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "cneshub.ingest")
 public class CkanProperties {
 
+    private String baseUrl;
+    private Datasets datasets = new Datasets();
+
+    @Data
+    public static class Datasets {
+        private String estabelecimentos;
+    }
 }

--- a/src/main/java/br/com/cneshub/config/CacheConfig.java
+++ b/src/main/java/br/com/cneshub/config/CacheConfig.java
@@ -1,5 +1,32 @@
 package br.com.cneshub.config;
 
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@Configuration
+@EnableCaching
 public class CacheConfig {
 
+    @Value("${cneshub.cache.ttl}")
+    private Duration ttl;
+
+    @Bean
+    public Caffeine<Object, Object> caffeine() {
+        return Caffeine.newBuilder().expireAfterWrite(ttl);
+    }
+
+    @Bean
+    public CacheManager cacheManager(Caffeine<Object, Object> caffeine) {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        manager.setCaffeine(caffeine);
+        return manager;
+    }
 }

--- a/src/main/java/br/com/cneshub/config/CorsConfig.java
+++ b/src/main/java/br/com/cneshub/config/CorsConfig.java
@@ -1,5 +1,14 @@
 package br.com.cneshub.config;
 
-public class CorsConfig {
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedOrigins("*").allowedMethods("*");
+    }
 }

--- a/src/main/java/br/com/cneshub/config/OpenApiConfig.java
+++ b/src/main/java/br/com/cneshub/config/OpenApiConfig.java
@@ -1,5 +1,17 @@
 package br.com.cneshub.config;
 
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class OpenApiConfig {
 
+    @Bean
+    public GroupedOpenApi api() {
+        return GroupedOpenApi.builder()
+                .group("cneshub")
+                .pathsToMatch("/api/**")
+                .build();
+    }
 }

--- a/src/main/java/br/com/cneshub/config/WebClientConfig.java
+++ b/src/main/java/br/com/cneshub/config/WebClientConfig.java
@@ -1,5 +1,43 @@
 package br.com.cneshub.config;
 
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import br.com.cneshub.client.CkanProperties;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.TcpClient;
+
+@Configuration
 public class WebClientConfig {
 
+    private final CkanProperties properties;
+
+    public WebClientConfig(CkanProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        TcpClient tcpClient = TcpClient.create()
+                .option(io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new io.netty.handler.timeout.ReadTimeoutHandler(10))
+                        .addHandlerLast(new io.netty.handler.timeout.WriteTimeoutHandler(10)));
+
+        HttpClient httpClient = HttpClient.from(tcpClient)
+                .compress(true)
+                .responseTimeout(Duration.ofSeconds(10));
+
+        return builder
+                .baseUrl(properties.getBaseUrl())
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.USER_AGENT, "cneshub-gateway")
+                .defaultHeader(HttpHeaders.ACCEPT_ENCODING, "gzip")
+                .build();
+    }
 }

--- a/src/main/java/br/com/cneshub/core/EstabelecimentoService.java
+++ b/src/main/java/br/com/cneshub/core/EstabelecimentoService.java
@@ -1,0 +1,34 @@
+package br.com.cneshub.core;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import br.com.cneshub.client.CkanClient;
+import br.com.cneshub.core.dto.CkanEnvelope;
+import br.com.cneshub.core.dto.CkanResponse;
+import br.com.cneshub.core.dto.EstabelecimentoDTO;
+import br.com.cneshub.core.dto.PageResponse;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EstabelecimentoService {
+
+    private final CkanClient client;
+
+    @Cacheable("estabelecimentos")
+    @CircuitBreaker(name = "ckan")
+    @Retry(name = "ckan")
+    @RateLimiter(name = "ckan")
+    public CkanEnvelope<EstabelecimentoDTO> buscar(String uf, String municipio, String tipo, int page, int size, String q) {
+        return client.buscar(uf, municipio, tipo, page, size, q);
+    }
+
+    public PageResponse<EstabelecimentoDTO> toPage(CkanEnvelope<EstabelecimentoDTO> envelope, int page, int size) {
+        CkanResponse<EstabelecimentoDTO> result = envelope.getResult();
+        return new PageResponse<>(result.getRecords(), page, size, result.getTotal());
+    }
+}

--- a/src/main/java/br/com/cneshub/core/dto/CkanEnvelope.java
+++ b/src/main/java/br/com/cneshub/core/dto/CkanEnvelope.java
@@ -1,0 +1,9 @@
+package br.com.cneshub.core.dto;
+
+import lombok.Data;
+
+@Data
+public class CkanEnvelope<T> {
+    private boolean success;
+    private CkanResponse<T> result;
+}

--- a/src/main/java/br/com/cneshub/core/dto/CkanResponse.java
+++ b/src/main/java/br/com/cneshub/core/dto/CkanResponse.java
@@ -1,5 +1,13 @@
 package br.com.cneshub.core.dto;
 
-public class CkanResponse {
+import java.util.List;
 
+import lombok.Data;
+
+@Data
+public class CkanResponse<T> {
+    private int total;
+    private int limit;
+    private int offset;
+    private List<T> records;
 }

--- a/src/main/java/br/com/cneshub/core/dto/EstabelecimentoDTO.java
+++ b/src/main/java/br/com/cneshub/core/dto/EstabelecimentoDTO.java
@@ -1,5 +1,24 @@
 package br.com.cneshub.core.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
 public class EstabelecimentoDTO {
 
+    @JsonProperty("co_cnes")
+    private String codigoCnes;
+
+    @JsonProperty("no_fantasia")
+    private String nomeFantasia;
+
+    @JsonProperty("co_tipo_estabelecimento")
+    private String tipo;
+
+    @JsonProperty("municipio")
+    private String municipio;
+
+    @JsonProperty("uf")
+    private String uf;
 }

--- a/src/main/java/br/com/cneshub/core/dto/PageResponse.java
+++ b/src/main/java/br/com/cneshub/core/dto/PageResponse.java
@@ -1,5 +1,17 @@
 package br.com.cneshub.core.dto;
 
-public class PageResponse {
+import java.util.List;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageResponse<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
 }

--- a/src/main/java/br/com/cneshub/core/service/CnesService.java
+++ b/src/main/java/br/com/cneshub/core/service/CnesService.java
@@ -1,5 +1,0 @@
-package br.com.cneshub.core.service;
-
-public class CnesService {
-
-}

--- a/src/main/java/br/com/cneshub/error/ApiExceptionHandler.java
+++ b/src/main/java/br/com/cneshub/error/ApiExceptionHandler.java
@@ -1,5 +1,33 @@
 package br.com.cneshub.error;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException.TooManyRequests;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import jakarta.validation.ConstraintViolationException;
+
+@RestControllerAdvice
 public class ApiExceptionHandler {
 
+    @ExceptionHandler({ MethodArgumentNotValidException.class, ConstraintViolationException.class,
+            IllegalArgumentException.class })
+    public ResponseEntity<String> handleBadRequest(Exception ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler({ TooManyRequests.class, RequestNotPermitted.class })
+    public ResponseEntity<String> handleTooMany(Exception ex) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body("Too many requests");
+    }
+
+    @ExceptionHandler({ WebClientResponseException.class, CallNotPermittedException.class, Exception.class })
+    public ResponseEntity<String> handleBadGateway(Exception ex) {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Upstream error");
+    }
 }

--- a/src/main/java/br/com/cneshub/error/ExternalServiceException.java
+++ b/src/main/java/br/com/cneshub/error/ExternalServiceException.java
@@ -1,5 +1,0 @@
-package br.com.cneshub.error;
-
-public class ExternalServiceException {
-
-}

--- a/src/main/java/br/com/cneshub/security/ApiKeyFilter.java
+++ b/src/main/java/br/com/cneshub/security/ApiKeyFilter.java
@@ -1,5 +1,38 @@
 package br.com.cneshub.security;
 
-public class ApiKeyFilter {
+import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class ApiKeyFilter extends OncePerRequestFilter {
+
+    @Value("${cneshub.security.apiKeyEnabled:false}")
+    private boolean enabled;
+
+    @Value("${cneshub.security.apiKey:}")
+    private String apiKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (!enabled) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String header = request.getHeader("X-API-Key");
+        if (apiKey != null && apiKey.equals(header)) {
+            filterChain.doFilter(request, response);
+        } else {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        }
+    }
 }

--- a/src/main/java/br/com/cneshub/security/SecurityConfig.java
+++ b/src/main/java/br/com/cneshub/security/SecurityConfig.java
@@ -1,5 +1,17 @@
 package br.com.cneshub.security;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
 public class SecurityConfig {
 
+    @Bean
+    public FilterRegistrationBean<ApiKeyFilter> apiKeyFilter(ApiKeyFilter filter) {
+        FilterRegistrationBean<ApiKeyFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
 }

--- a/src/main/java/br/com/cneshub/util/PaginationUtils.java
+++ b/src/main/java/br/com/cneshub/util/PaginationUtils.java
@@ -1,5 +1,0 @@
-package br.com.cneshub.util;
-
-public class PaginationUtils {
-
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ cneshub:
     baseUrl: https://opendatasus.saude.gov.br/api/3/action
     datasets:
       estabelecimentos: <RESOURCE_ID>
+  cache:
+    ttl: 5m
   security:
     apiKeyEnabled: false
     apiKey: trocar-em-producao


### PR DESCRIPTION
## Summary
- adiciona dependências web, webflux, cache, resilience4j, springdoc e utilitários
- implementa WebClient, cache Caffeine, OpenAPI e CORS
- cria cliente CKAN, serviço com Resilience4j e endpoint paginado
- adiciona filtro opcional de API key e tratador de erros

## Testing
- `mvn -q -DskipTests clean package` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48dcb0dd8832a824dcca254cdff03