### PR TITLE
feat: add CKAN package list endpoint

### DIFF
--- a/src/main/java/br/com/cneshub/api/v1/CatalogController.java
+++ b/src/main/java/br/com/cneshub/api/v1/CatalogController.java
@@ -1,0 +1,41 @@
+package br.com.cneshub.api.v1;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.cneshub.core.dto.PackageListResponse;
+import br.com.cneshub.core.service.CnesService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/catalog")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Catálogo")
+public class CatalogController {
+
+    private final CnesService service;
+
+    @GetMapping("/packages")
+    @Operation(summary = "Lista pacotes", description = "Retorna lista de datasets do CKAN")
+    public ResponseEntity<PackageListResponse> listarPacotes(
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(200) int size,
+            @RequestParam(required = false) String q) {
+        PackageListResponse response = service.listarPacotes(page, size, q);
+        CacheControl cache = CacheControl.maxAge(60, TimeUnit.SECONDS).cachePublic();
+        return ResponseEntity.ok().cacheControl(cache).body(response);
+    }
+}
+

--- a/src/main/java/br/com/cneshub/client/CkanClient.java
+++ b/src/main/java/br/com/cneshub/client/CkanClient.java
@@ -1,11 +1,14 @@
 package br.com.cneshub.client;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,7 +16,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import br.com.cneshub.core.dto.CkanEnvelope;
 import br.com.cneshub.core.dto.EstabelecimentoDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CkanClient {
@@ -55,5 +60,17 @@ public class CkanClient {
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<CkanEnvelope<EstabelecimentoDTO>>() {})
                 .block();
+    }
+
+    public Mono<List<String>> packageList() {
+        return webClient.get()
+                .uri("/package_list")
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<CkanPackageListEnvelope>() {})
+                .map(CkanPackageListEnvelope::result)
+                .doOnError(e -> log.error("Erro ao buscar lista de pacotes", e));
+    }
+
+    private record CkanPackageListEnvelope(boolean success, List<String> result) {
     }
 }

--- a/src/main/java/br/com/cneshub/core/dto/PackageItem.java
+++ b/src/main/java/br/com/cneshub/core/dto/PackageItem.java
@@ -1,0 +1,17 @@
+package br.com.cneshub.core.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Item de pacote")
+public class PackageItem {
+
+    @Schema(description = "Nome do pacote")
+    private String name;
+}
+

--- a/src/main/java/br/com/cneshub/core/dto/PackageListResponse.java
+++ b/src/main/java/br/com/cneshub/core/dto/PackageListResponse.java
@@ -1,0 +1,28 @@
+package br.com.cneshub.core.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Resposta da lista de pacotes")
+public class PackageListResponse {
+
+    @Schema(description = "Total de pacotes")
+    private int total;
+
+    @Schema(description = "Página atual (0-based)")
+    private int page;
+
+    @Schema(description = "Tamanho da página")
+    private int size;
+
+    @Schema(description = "Itens da página")
+    private List<PackageItem> items;
+}
+

--- a/src/main/java/br/com/cneshub/core/service/CnesService.java
+++ b/src/main/java/br/com/cneshub/core/service/CnesService.java
@@ -1,0 +1,53 @@
+package br.com.cneshub.core.service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+
+import br.com.cneshub.client.CkanClient;
+import br.com.cneshub.core.dto.PackageItem;
+import br.com.cneshub.core.dto.PackageListResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CnesService {
+
+    private final CkanClient client;
+
+    @Cacheable(cacheNames = "ckan:package_list", key = "T(java.util.Objects).hash(#page,#size,#q)")
+    public PackageListResponse listarPacotes(int page, int size, @Nullable String q) {
+        List<String> packages = client.packageList().block();
+        if (packages == null) {
+            packages = List.of();
+        }
+
+        List<String> processed = packages.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .collect(Collectors.toList());
+
+        if (q != null && !q.isBlank()) {
+            String query = q.toLowerCase();
+            processed = processed.stream()
+                    .filter(name -> name.toLowerCase().contains(query))
+                    .collect(Collectors.toList());
+        }
+
+        int total = processed.size();
+        int from = Math.min(page * size, total);
+        int to = Math.min(from + size, total);
+
+        List<PackageItem> items = processed.subList(from, to).stream()
+                .map(PackageItem::new)
+                .collect(Collectors.toList());
+
+        return new PackageListResponse(total, page, size, items);
+    }
+}
+

--- a/src/main/java/br/com/cneshub/error/ApiExceptionHandler.java
+++ b/src/main/java/br/com/cneshub/error/ApiExceptionHandler.java
@@ -11,7 +11,9 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestControllerAdvice
 public class ApiExceptionHandler {
 
@@ -28,6 +30,7 @@ public class ApiExceptionHandler {
 
     @ExceptionHandler({ WebClientResponseException.class, CallNotPermittedException.class, Exception.class })
     public ResponseEntity<String> handleBadGateway(Exception ex) {
+        log.error("Erro ao consultar serviço upstream", ex);
         return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Upstream error");
     }
 }


### PR DESCRIPTION
## Summary
- add client call to CKAN /package_list with error logging
- expose catalog packages endpoint with filtering and pagination
- cache package listings and improve upstream error logging

## Testing
- `mvn -q -DskipTests clean package` *(fails: Network is unreachable)*
- `./mvnw -q -DskipTests clean package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a490a89fd0832ab28a23df80eb2a7f