### PR TITLE
Fix SpringDoc configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
             <dependency>
               <groupId>org.springdoc</groupId>
               <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+              <version>2.5.0</version>
             </dependency>
 
             <!-- Utilidades -->

--- a/src/main/java/br/com/cneshub/config/OpenApiConfig.java
+++ b/src/main/java/br/com/cneshub/config/OpenApiConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class OpenApiConfig {
 
     @Bean
-    public GroupedOpenApi api() {
+    GroupedOpenApi api() {
         return GroupedOpenApi.builder()
                 .group("cneshub")
                 .pathsToMatch("/api/**")


### PR DESCRIPTION
## Summary
- add explicit version for springdoc-openapi-starter-webmvc-ui
- adjust OpenAPI bean method visibility

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM for br.com.cneshub:br-cnes-hub-api:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a49534e9e8832aa5af424e21015b24