### PR TITLE
Specify Resilience4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
             <dependency>
               <groupId>io.github.resilience4j</groupId>
               <artifactId>resilience4j-spring-boot3</artifactId>
+              <version>2.3.0</version>
             </dependency>
 
             <!-- Documentação OpenAPI/Swagger -->


### PR DESCRIPTION
## Summary
- specify explicit 2.3.0 version for `resilience4j-spring-boot3` to allow Spring annotations to resolve

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4980301b4832abe7a264a3d650493