### PR TITLE
fix: finalize filtrosJson for lambda

### DIFF
--- a/src/main/java/br/com/cneshub/client/CkanClient.java
+++ b/src/main/java/br/com/cneshub/client/CkanClient.java
@@ -34,13 +34,15 @@ public class CkanClient {
         if (municipio != null) filtros.put("municipio", municipio);
         if (tipo != null) filtros.put("co_tipo_estabelecimento", tipo);
 
-        String filtrosJson = null;
+        final String filtrosJson;
         if (!filtros.isEmpty()) {
             try {
                 filtrosJson = mapper.writeValueAsString(filtros);
             } catch (JsonProcessingException e) {
                 throw new IllegalArgumentException("Erro ao serializar filtros", e);
             }
+        } else {
+            filtrosJson = null;
         }
 
         return webClient.get()


### PR DESCRIPTION
## Summary
- ensure `filtrosJson` is `final` so it can be used in lambda

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for br.com.cneshub:br-cnes-hub-api:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a49bf5ffbc832a878fb8b5f17ea747