### PR TITLE
Fix bean name clash in security configuration

### DIFF
--- a/src/main/java/br/com/cneshub/security/SecurityConfig.java
+++ b/src/main/java/br/com/cneshub/security/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.core.Ordered;
 public class SecurityConfig {
 
     @Bean
-    public FilterRegistrationBean<ApiKeyFilter> apiKeyFilter(ApiKeyFilter filter) {
+    public FilterRegistrationBean<ApiKeyFilter> apiKeyFilterRegistration(ApiKeyFilter filter) {
         FilterRegistrationBean<ApiKeyFilter> registration = new FilterRegistrationBean<>(filter);
         registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
         return registration;


### PR DESCRIPTION
## Summary
- Rename `apiKeyFilter` bean registration method to `apiKeyFilterRegistration` to avoid bean name collision with `ApiKeyFilter` component

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ae8956f8832a9309d1cd90f8bc40