### PR TITLE
Fix duplicate CkanProperties bean definition

### DIFF
--- a/src/main/java/br/com/cneshub/client/CkanProperties.java
+++ b/src/main/java/br/com/cneshub/client/CkanProperties.java
@@ -1,12 +1,10 @@
 package br.com.cneshub.client;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 import lombok.Data;
 
 @Data
-@Component
 @ConfigurationProperties(prefix = "cneshub.ingest")
 public class CkanProperties {
 


### PR DESCRIPTION
## Summary
- avoid multiple CkanProperties beans by removing redundant `@Component`

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b0e29390832aad8b5514090a0202