### PR TITLE
chore: upgrade springdoc-openapi for spring 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
           <groupId>org.springdoc</groupId>
           <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-          <version>2.5.0</version>
+          <version>2.8.9</version>
         </dependency>
 
         <!-- Utilidades -->


### PR DESCRIPTION
## Summary
- align Springdoc with Spring Boot 3.5 by bumping `springdoc-openapi-starter-webmvc-ui` to 2.8.9

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b50f8b14832ab4a03718d861b050