### PR TITLE
Expose versioned OpenAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,8 @@ Requisitos: Java 21 e Maven.
 mvn spring-boot:run
 ```
 
+## 📚 Documentação
+Após iniciar a aplicação, a especificação OpenAPI pode ser acessada em `/v1/api-docs`.
+
 ## 📄 Licença
 Distribuído sob a [MIT License](LICENSE).

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,10 @@ spring:
   main:
     web-application-type: servlet
 
+springdoc:
+  api-docs:
+    path: /v1/api-docs
+
 cneshub:
   ingest:
     baseUrl: https://opendatasus.saude.gov.br/api/3/action


### PR DESCRIPTION
## Summary
- serve OpenAPI spec at `/v1/api-docs`
- document the new OpenAPI endpoint in the README

## Testing
- `mvn -q test` *(fails: could not resolve parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fb10a53c832a91fe59a14f1c38c9