### PR TITLE
fix: configure Swagger UI to use correct API docs path

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,8 @@ spring:
 springdoc:
   api-docs:
     path: /v1/api-docs
+  swagger-ui:
+    url: /v1/api-docs
 
 cneshub:
   ingest:


### PR DESCRIPTION
## Summary
- ensure Swagger UI references the custom `/v1/api-docs` path

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ffc93560832a953e8af0467d57e1