### PR TITLE
Fix Swagger UI config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,6 @@ spring:
 springdoc:
   api-docs:
     path: /v1/api-docs
-  swagger-ui:
-    url: /v1/api-docs
 
 cneshub:
   ingest:


### PR DESCRIPTION
## Summary
- remove wrong `springdoc.swagger-ui.url` configuration so Swagger UI loads the generated OpenAPI definition

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a50218ed54832a8db4406922dc6aff