### PR TITLE
chore: update springdoc version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
           <groupId>org.springdoc</groupId>
           <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-          <version>2.6.0</version>
+          <version>2.8.6</version>
         </dependency>
 
         <!-- Utilidades -->


### PR DESCRIPTION
## Summary
- upgrade springdoc-openapi-starter-webmvc-ui to 2.8.6 for Spring 6.2 compatibility

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for br.com.cneshub:br-cnes-hub-api:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a50830b2dc832aab6ad655a1102d9e